### PR TITLE
Extending Kohana_Controller_Template in Controller_Userguide

### DIFF
--- a/classes/controller/userguide.php
+++ b/classes/controller/userguide.php
@@ -6,7 +6,7 @@
  * @category   Controllers
  * @author     Kohana Team
  */
-class Controller_Userguide extends Controller_Template {
+class Controller_Userguide extends Kohana_Controller_Template {
 
 	public $template = 'userguide/template';
 


### PR DESCRIPTION
Hi.
I think that it would better to extend Kohana_Controller_Template in Controller_Userguide instead of Controller_Template to avoid crossings with Template extentions in application (making apps Template Controller, based on Kohana_Controller_Template).
