### PR TITLE
3.2/feature/3529 exclude configurable transparent classes

### DIFF
--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -65,8 +65,8 @@ class Kohana_Kodoc {
 
 		foreach ($classes as $class)
 		{
-                        if (Kodoc::is_transparent($class, $classes))
-                            continue;
+			if (Kodoc::is_transparent($class, $classes))
+				continue;
 
 			$class = Kodoc_Class::factory($class);
 
@@ -154,17 +154,15 @@ class Kohana_Kodoc {
 	 */
 	public static function class_methods(array $list = NULL)
 	{
-		$list = Kodoc::classes($list);                
+		$list = Kodoc::classes($list);
 
 		$classes = array();
 
 		foreach ($list as $class)
 		{
-                        // Skip transparent extension classes
-                        if (KoDoc::is_transparent($class))
-                        {
-                            continue;
-                        }
+			// Skip transparent extension classes
+			if (KoDoc::is_transparent($class))
+				continue;
 
 			$_class = new ReflectionClass($class);
 
@@ -174,9 +172,9 @@ class Kohana_Kodoc {
 			{
 				$declares = $_method->getDeclaringClass()->name;
 
-                                // Remove the transparent prefix from declaring classes
-                                if ($child = KoDoc::is_transparent($declares))
-				{					
+				// Remove the transparent prefix from declaring classes
+				if ($child = KoDoc::is_transparent($declares))
+				{
 					$declares = $child;
 				}
 
@@ -344,69 +342,73 @@ class Kohana_Kodoc {
 		return $show_this;
 	}
 
-        /**
-         * Checks whether a class is a transparent extension class or not. The old
-         * code takes two approaches - [Kodoc::menu] checks if the extension class
-         * actually exists, while [Kodoc::class_methods] does not.
-         *
-         * This method takes an optional $classes parameter, a list of all defined
-         * class names. If provided, the method will return false unless the extension
-         * class exists. If not, the method will only check known transparent class
-         * prefixes.
+	/**
+	 * Checks whether a class is a transparent extension class or not. The old
+	 * code takes two approaches - [Kodoc::menu] checks if the extension class
+	 * actually exists, while [Kodoc::class_methods] does not.
+	 *
+	 * This method takes an optional $classes parameter, a list of all defined
+	 * class names. If provided, the method will return false unless the extension
+	 * class exists. If not, the method will only check known transparent class
+	 * prefixes.
 	 *
 	 * [!!] The $classes parameter is expected to be a result from Kodoc::classes
 	 * and will therefore contain lowercased class names. When $classes is provided,
 	 * $class must also be lowercase, or an exception will be thrown.
-         *
-         * Transparent prefixes are defined in the userguide.php config file in
-         * *lowercase*:
-         *
-         *     'transparent_prefixes' => array(
-         *         'kohana' => true,
-         *     );
-         *
-         * Module developers can therefore add their own transparent extension
-         * namespaces and exclude them from the userguide.
-         *          
-         * @param string $class The name of the class to check for transparency
-         * @param array $classes An optional list of all defined classes
-         * @return false If this is not a transparent extension class 
-         * @return string The name of the class that extends this (in the case provided)
+	 *
+	 * Transparent prefixes are defined in the userguide.php config file in
+	 * *lowercase*:
+	 *
+	 *     'transparent_prefixes' => array(
+	 *         'kohana' => true,
+	 *     );
+	 *
+	 * Module developers can therefore add their own transparent extension
+	 * namespaces and exclude them from the userguide.
+	 *          
+	 * @param string $class The name of the class to check for transparency
+	 * @param array $classes An optional list of all defined classes
+	 * @return false If this is not a transparent extension class 
+	 * @return string The name of the class that extends this (in the case provided)
 	 * @throws InvalidArgumentException If the $classes array is provided and the $class variable is not lowercase
-         */
-        public static function is_transparent($class, $classes = null)
-        {
-	    if ($classes AND ($class != strtolower($class)))
-	    {
-		throw new InvalidArgumentException("KoDoc::is_transparent expects lowercase \$class when \$classes array is provided.");
-	    }
+	 */
+	public static function is_transparent($class, $classes = null)
+	{
+		if ($classes AND ($class != strtolower($class)))
+		{
+			throw new InvalidArgumentException("KoDoc::is_transparent expects lowercase \$class when \$classes array is provided.");
+		}
 
-            static $transparent_prefixes = null;
+		static $transparent_prefixes = null;
 
-            if ( ! $transparent_prefixes)
-            {
-                $transparent_prefixes = Kohana::config('userguide.transparent_prefixes');
-            }
+		if ( ! $transparent_prefixes)
+		{
+			$transparent_prefixes = Kohana::config('userguide.transparent_prefixes');
+		}
 
-            // Hack for Kohana_Core, which doesn't follow convention
-            if ($class == 'Kohana_Core') {
-                return 'Kohana';
-            } else if ($class == 'kohana_core') {
-                return 'kohana';
-            }
+		// Hack for Kohana_Core, which doesn't follow convention
+		if ($class == 'Kohana_Core') 
+		{
+			return 'Kohana';
+		} 
+		elseif ($class == 'kohana_core') 
+		{
+			return 'kohana';
+		}
 
-            // For all others, split into the two elements of the class name
-            $segments = explode('_',$class,2);
+		// For all others, split into the two elements of the class name
+		$segments = explode('_',$class,2);
 
-            $result = (count($segments) == 2)
-                      && (isset($transparent_prefixes[strtolower($segments[0])]));
+		$result = (count($segments) == 2)
+		          && (isset($transparent_prefixes[strtolower($segments[0])]));
 
-            if ($result AND $classes) {
-                $result = $result && isset($classes[$segments[1]]);
-            }
+		if ($result AND $classes) 
+		{
+			$result = $result && isset($classes[$segments[1]]);
+		}
 
-            return $result ? $segments[1] : false;
-        }
+		return $result ? $segments[1] : false;
+	}
 
 
 } // End Kodoc

--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -346,15 +346,15 @@ class Kohana_Kodoc {
 
         /**
          * Checks whether a class is a transparent extension class or not. The old
-         * code takes two approaches - [KoDoc::menu] checks if the extension class
-         * actually exists, while [KoDoc::class_methods] does not.
+         * code takes two approaches - [Kodoc::menu] checks if the extension class
+         * actually exists, while [Kodoc::class_methods] does not.
          *
          * This method takes an optional $classes parameter, a list of all defined
          * class names. If provided, the method will return false unless the extension
          * class exists. If not, the method will only check known transparent class
          * prefixes.
 	 *
-	 * [!!] The $classes parameter is expected to be a result from KoDoc::classes
+	 * [!!] The $classes parameter is expected to be a result from Kodoc::classes
 	 * and will therefore contain lowercased class names. When $classes is provided,
 	 * $class must also be lowercase, or an exception will be thrown.
          *

--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -161,7 +161,7 @@ class Kohana_Kodoc {
 		foreach ($list as $class)
 		{
 			// Skip transparent extension classes
-			if (KoDoc::is_transparent($class))
+			if (Kodoc::is_transparent($class))
 				continue;
 
 			$_class = new ReflectionClass($class);
@@ -173,7 +173,7 @@ class Kohana_Kodoc {
 				$declares = $_method->getDeclaringClass()->name;
 
 				// Remove the transparent prefix from declaring classes
-				if ($child = KoDoc::is_transparent($declares))
+				if ($child = Kodoc::is_transparent($declares))
 				{
 					$declares = $child;
 				}
@@ -376,7 +376,7 @@ class Kohana_Kodoc {
 	{
 		if ($classes AND ($class != strtolower($class)))
 		{
-			throw new InvalidArgumentException("KoDoc::is_transparent expects lowercase \$class when \$classes array is provided.");
+			throw new InvalidArgumentException("Kodoc::is_transparent expects lowercase \$class when \$classes array is provided.");
 		}
 
 		static $transparent_prefixes = null;

--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -353,6 +353,10 @@ class Kohana_Kodoc {
          * class names. If provided, the method will return false unless the extension
          * class exists. If not, the method will only check known transparent class
          * prefixes.
+	 *
+	 * [!!] The $classes parameter is expected to be a result from KoDoc::classes
+	 * and will therefore contain lowercased class names. When $classes is provided,
+	 * $class must also be lowercase, or an exception will be thrown.
          *
          * Transparent prefixes are defined in the userguide.php config file in
          * *lowercase*:
@@ -368,9 +372,15 @@ class Kohana_Kodoc {
          * @param array $classes An optional list of all defined classes
          * @return false If this is not a transparent extension class 
          * @return string The name of the class that extends this (in the case provided)
+	 * @throws InvalidArgumentException If the $classes array is provided and the $class variable is not lowercase
          */
         public static function is_transparent($class, $classes = null)
         {
+	    if ($classes AND ($class != strtolower($class)))
+	    {
+		throw new InvalidArgumentException("KoDoc::is_transparent expects lowercase \$class when \$classes array is provided.");
+	    }
+
             static $transparent_prefixes = null;
 
             if ( ! $transparent_prefixes)
@@ -392,7 +402,7 @@ class Kohana_Kodoc {
                       && (isset($transparent_prefixes[strtolower($segments[0])]));
 
             if ($result AND $classes) {
-                $result = $result && isset($classes[strtolower($segments[1])]);
+                $result = $result && isset($classes[$segments[1]]);
             }
 
             return $result ? $segments[1] : false;

--- a/classes/kohana/kodoc/class.php
+++ b/classes/kohana/kodoc/class.php
@@ -14,7 +14,7 @@ class Kohana_Kodoc_Class extends Kodoc {
 	 * @var  ReflectionClass The ReflectionClass for this class
 	 */
 	public $class;
-
+	
 	/**
 	 * @var  string  modifiers like abstract, final
 	 */

--- a/classes/kohana/kodoc/class.php
+++ b/classes/kohana/kodoc/class.php
@@ -14,7 +14,7 @@ class Kohana_Kodoc_Class extends Kodoc {
 	 * @var  ReflectionClass The ReflectionClass for this class
 	 */
 	public $class;
-	
+
 	/**
 	 * @var  string  modifiers like abstract, final
 	 */

--- a/config/userguide.php
+++ b/config/userguide.php
@@ -29,8 +29,8 @@ return array
 		)	
 	),
 
-        // Set transparent class name segments
-        'transparent_prefixes' => array(
-            'kohana' => true
-        )
+	// Set transparent class name segments
+	'transparent_prefixes' => array(
+		'kohana' => true
+	)
 );

--- a/config/userguide.php
+++ b/config/userguide.php
@@ -27,5 +27,10 @@ return array
 			// Copyright message, shown in the footer for this module
 			'copyright' => '&copy; 2008–2010 Kohana Team',
 		)	
-	)
+	),
+
+        // Set transparent class name segments
+        'transparent_prefixes' => array(
+            'kohana' => true
+        )
 );

--- a/guide/userguide/adding.md
+++ b/guide/userguide/adding.md
@@ -32,9 +32,9 @@ First, copy this config and place in it `<module>/config/userguide.php`, replaci
 		 * For example, if you use Modulename_<class_name>, then you would define:
 		 */
 		'transparent_prefixes' => array(
-		    'modulename' => true,
+			'modulename' => true,
 		)
-    );
+	);
 
 Next, create a folder in your module directory called `guide/<modulename>` and create `index.md` and `menu.md`.  All userguide pages use [Markdown](markdown).  The index page is what is shown on the index of your module, the menu is what shows up in the side column.  The menu should be formatted like this:
 

--- a/guide/userguide/adding.md
+++ b/guide/userguide/adding.md
@@ -24,8 +24,17 @@ First, copy this config and place in it `<module>/config/userguide.php`, replaci
 				// Copyright message, shown in the footer for this module
 				'copyright' => '&copy; 2010–2010 <Your Name>',
 			)	
+		),
+
+		/*
+		 * If you use transparent extension outside the Kohana_ namespace,
+		 * add your class prefix here (in lowercase).
+		 * For example, if you use Modulename_<class_name>, then you would define:
+		 */
+		'transparent_prefixes' => array(
+		    'modulename' => true,
 		)
-	);
+    );
 
 Next, create a folder in your module directory called `guide/<modulename>` and create `index.md` and `menu.md`.  All userguide pages use [Markdown](markdown).  The index page is what is shown on the index of your module, the menu is what shows up in the side column.  The menu should be formatted like this:
 

--- a/tests/userguide/KoDocTest.php
+++ b/tests/userguide/KoDocTest.php
@@ -5,56 +5,58 @@
  */
 class KodocTest extends Kohana_Unittest_TestCase
 {
-    const EXPECT_EXCEPTION = -1;
+	const EXPECT_EXCEPTION = -1;
 
-    /**
-     * Provides test data for test_transparent_classes
-     * @return array
-     */
-    public function provider_transparent_classes()
-    {
-	return array(
-	    //Kohana_Core is a special case
-	    array('kohana','kohana_core',null),
-	    array('Controller_Template','Kohana_Controller_Template',null),
-	    array('controller_template','kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template',
-	                                                                   'controller_template'=>'controller_template')),
-	    array(false,'kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template')),
-	    array(false,'Controller_Template',null),
-	    array(self::EXPECT_EXCEPTION,'Kohana_Controller_Template',array('kohana_controller_template'=>'kohana_controller_template'))
-	    );
-    }
-
-    /**
-     * Tests Kodoc::is_transparent
-     *
-     * Checks that a selection of transparent and non-transparent classes give expected results
-     *
-     * @group userguide.feat3529-configurable-transparent-classes
-     * @dataProvider provider_transparent_classes
-     * @param mixed $expected
-     * @param string $class
-     * @param array $classes
-     */
-    public function test_transparent_classes($expected, $class, $classes)
-    {
-	try
+	/**
+	 * Provides test data for test_transparent_classes
+	 * @return array
+	 */
+	public function provider_transparent_classes()
 	{
-	    $result = Kodoc::is_transparent($class, $classes);
-
-	    if ($expected == self::EXPECT_EXCEPTION)
-	    {
-		$this->fail('Kodoc::is_transparent did not throw an expected InvalidArgumentException');
-	    } else {
-		$this->assertSame($expected,$result);
-	    }
-	} catch (InvalidArgumentException $e) {
-	    if ($expected != self::EXPECT_EXCEPTION)
-	    {
-		// We weren't expecting that
-		$this->fail('Kodoc::is_transparent threw unexpected InvalidArgumentException with message '.$e->getMessage());
-	    }	    
+		return array(
+			//Kohana_Core is a special case
+			array('kohana','kohana_core',null),
+			array('Controller_Template','Kohana_Controller_Template',null),
+			array('controller_template','kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template',
+			                                                               'controller_template'=>'controller_template')),
+		array(false,'kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template')),
+		array(false,'Controller_Template',null),
+		array(self::EXPECT_EXCEPTION,'Kohana_Controller_Template',array('kohana_controller_template'=>'kohana_controller_template'))
+		);
 	}
 
-    }
+	/**
+	 * Tests Kodoc::is_transparent
+	 *
+	 * Checks that a selection of transparent and non-transparent classes give expected results
+	 *
+	 * @group userguide.feat3529-configurable-transparent-classes
+	 * @dataProvider provider_transparent_classes
+	 * @param mixed $expected
+	 * @param string $class
+	 * @param array $classes
+	 */
+	public function test_transparent_classes($expected, $class, $classes)
+	{
+		try
+		{
+			$result = Kodoc::is_transparent($class, $classes);
+
+			if ($expected == self::EXPECT_EXCEPTION)
+			{
+				$this->fail('Kodoc::is_transparent did not throw an expected InvalidArgumentException');
+			} 
+			else 
+			{
+				$this->assertSame($expected,$result);
+			}
+		} catch (InvalidArgumentException $e) {
+			if ($expected != self::EXPECT_EXCEPTION)
+			{
+				// We weren't expecting that
+				$this->fail('Kodoc::is_transparent threw unexpected InvalidArgumentException with message '.$e->getMessage());
+			}
+		}
+
+	}
 }

--- a/tests/userguide/KoDocTest.php
+++ b/tests/userguide/KoDocTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for the KoDoc userguide class
+ * @group userguide
+ */
+class KoDocTest extends Kohana_Unittest_TestCase
+{
+    const EXPECT_EXCEPTION = -1;
+
+    /**
+     * Provides test data for test_transparent_classes
+     * @return array
+     */
+    public function provider_transparent_classes()
+    {
+	return array(
+	    //Kohana_Core is a special case
+	    array('kohana','kohana_core',null),
+	    array('Controller_Template','Kohana_Controller_Template',null),
+	    array('controller_template','kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template',
+	                                                                   'controller_template'=>'controller_template')),
+	    array(false,'kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template')),
+	    array(false,'Controller_Template',null),
+	    array(self::EXPECT_EXCEPTION,'Kohana_Controller_Template',array('kohana_controller_template'=>'kohana_controller_template'))
+	    );
+    }
+
+    /**
+     * Tests KoDoc::is_transparent
+     *
+     * Checks that a selection of transparent and non-transparent classes give expected results
+     *
+     * @group userguide.feat3529-configurable-transparent-classes
+     * @dataProvider provider_transparent_classes
+     * @param mixed $expected
+     * @param string $class
+     * @param array $classes
+     */
+    public function test_transparent_classes($expected, $class, $classes)
+    {
+	try
+	{
+	    $result = KoDoc::is_transparent($class, $classes);
+
+	    if ($expected == self::EXPECT_EXCEPTION)
+	    {
+		$this->fail('KoDoc::is_transparent did not throw an expected InvalidArgumentException');
+	    } else {
+		$this->assertSame($expected,$result);
+	    }
+	} catch (InvalidArgumentException $e) {
+	    if ($expected != self::EXPECT_EXCEPTION)
+	    {
+		// We weren't expecting that
+		$this->fail('KoDoc::is_transparent threw unexpected InvalidArgumentException with message '.$e->getMessage());
+	    }	    
+	}
+
+    }
+}

--- a/tests/userguide/KoDocTest.php
+++ b/tests/userguide/KoDocTest.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tests for the KoDoc userguide class
+ * Tests for the Kodoc userguide class
  * @group userguide
  */
-class KoDocTest extends Kohana_Unittest_TestCase
+class KodocTest extends Kohana_Unittest_TestCase
 {
     const EXPECT_EXCEPTION = -1;
 
@@ -26,7 +26,7 @@ class KoDocTest extends Kohana_Unittest_TestCase
     }
 
     /**
-     * Tests KoDoc::is_transparent
+     * Tests Kodoc::is_transparent
      *
      * Checks that a selection of transparent and non-transparent classes give expected results
      *
@@ -40,11 +40,11 @@ class KoDocTest extends Kohana_Unittest_TestCase
     {
 	try
 	{
-	    $result = KoDoc::is_transparent($class, $classes);
+	    $result = Kodoc::is_transparent($class, $classes);
 
 	    if ($expected == self::EXPECT_EXCEPTION)
 	    {
-		$this->fail('KoDoc::is_transparent did not throw an expected InvalidArgumentException');
+		$this->fail('Kodoc::is_transparent did not throw an expected InvalidArgumentException');
 	    } else {
 		$this->assertSame($expected,$result);
 	    }
@@ -52,7 +52,7 @@ class KoDocTest extends Kohana_Unittest_TestCase
 	    if ($expected != self::EXPECT_EXCEPTION)
 	    {
 		// We weren't expecting that
-		$this->fail('KoDoc::is_transparent threw unexpected InvalidArgumentException with message '.$e->getMessage());
+		$this->fail('Kodoc::is_transparent threw unexpected InvalidArgumentException with message '.$e->getMessage());
 	    }	    
 	}
 

--- a/views/userguide/api/class.php
+++ b/views/userguide/api/class.php
@@ -6,6 +6,13 @@
 	<?php endwhile ?>
 </h1>
 
+<?php if ($child = $doc->is_transparent($doc->class->name)):?>
+<p class="note">
+This class is a transparent base class for <?php echo HTML::anchor($route->uri(array('class'=>$child)),$child) ?> and
+should not be accessed directly.
+</p>
+<?php endif;?>
+
 <?php echo $doc->description ?>
 
 <?php if ($doc->tags): ?>


### PR DESCRIPTION
Implements @3529 - Exclude configurable transparent classes from the userguide API browser (rather than just classes in Kohana_ namespace).

Currently based on 3.0.x but understand this will be a 3.2 feature - happy to rebase as required per my post on Redmine.

This is my first contribution to Kohana - any feedback on implementation or workflow very welcome.
