### PR TITLE
3.2/feature/3486 show class interfaces

### DIFF
--- a/views/userguide/api/class.php
+++ b/views/userguide/api/class.php
@@ -6,6 +6,18 @@
 	<?php endwhile ?>
 </h1>
 
+<?php if ($interfaces = $doc->class->getInterfaceNames()):?>
+<p class="interfaces"><small>
+Implements:
+<?php
+for ($i = 0, $split = false, $count = count($interfaces); $i < $count; $i++, $split=" | ")
+{
+    echo $split . HTML::anchor($route->uri(array('class' => $interfaces[$i])),$interfaces[$i]);
+}
+?></small>
+</p>
+<?php endif;?>
+
 <?php echo $doc->description ?>
 
 <?php if ($doc->tags): ?>


### PR DESCRIPTION
Implements ticket @3486 - show class interfaces in the API browser. I haven't done anything to style the output.
