### PR TITLE
Patch for #3711: Unittest module breaks the userguide api browser

### DIFF
--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -373,12 +373,21 @@ class Kohana_Kodoc {
 		try
 		{
 			// Transform the class name into a path
-			$path = str_replace('_', '/', strtolower($class)) . ".php";
+			$file = str_replace('_', '/', strtolower($class)) . ".php";
 
 			// Load the class file
-			require $path;
+			$exists = false;
+			foreach (explode(':', get_include_path()) as $path)
+			{
+				if (is_file($path.$file))
+				{
+					require $path.$file;
+					$exists = true;
+					break;
+				}
+			}
 
-			return class_exists($class);
+			return $exists;
 		}
 		catch (Exception $e)
 		{

--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -373,21 +373,12 @@ class Kohana_Kodoc {
 		try
 		{
 			// Transform the class name into a path
-			$pear = "/usr/lib/php/"; // Need a better way to do this....
-			$file = str_replace('_', '/', strtolower($class));
-			$path = $pear.$file.".php";
+			$path = str_replace('_', '/', strtolower($class)) . ".php";
 
-			if (is_file($path))
-			{
-				// Load the class file
-				require $path;
+			// Load the class file
+			require $path;
 
-				// Class has been found
-				return TRUE;
-			}
-
-			// Class is not in the filesystem
-			return FALSE;
+			return class_exists($class);
 		}
 		catch (Exception $e)
 		{

--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -350,5 +350,50 @@ class Kohana_Kodoc {
 		return $show_this;
 	}
 
+	/**
+	 * Provides auto-loading support of classes that are install by PEAR (e.g. PHPUnit)
+	 * so the API browser doesn't break when classes are used in a module by PEAR.
+	 *
+	 * Class names are converted to file names by making the class name
+	 * lowercase and converting underscores to slashes:
+	 *
+	 * You should never have to call this function, as simply calling a class
+	 * will cause it to be called.
+	 *
+	 * This function must be enabled as an autoloader in the init.php file of
+	 * the userguide module:
+	 *
+	 *     spl_autoload_register(array('Kodoc', 'auto_load'));
+	 *
+	 * @param   string   class name
+	 * @return  boolean
+	 */
+	public static function auto_load($class)
+	{
+		try
+		{
+			// Transform the class name into a path
+			$pear = "/usr/lib/php/"; // Need a better way to do this....
+			$file = str_replace('_', '/', strtolower($class));
+			$path = $pear.$file.".php";
+
+			if (is_file($path))
+			{
+				// Load the class file
+				require $path;
+
+				// Class has been found
+				return TRUE;
+			}
+
+			// Class is not in the filesystem
+			return FALSE;
+		}
+		catch (Exception $e)
+		{
+			Kohana_Exception::handler($e);
+			die;
+		}
+	}
 
 } // End Kodoc

--- a/init.php
+++ b/init.php
@@ -17,6 +17,8 @@ if (Kohana::config('userguide.api_browser') === TRUE)
 			'action'     => 'api',
 			'class'      => NULL,
 		));
+
+	spl_autoload_register(array('Kodoc', 'auto_load'));
 }
 
 // User guide pages, in modules


### PR DESCRIPTION
This patch should close #3711. It adds an autoloader which looks through the include_path that is set in php for any classes that can't be found within the API browser (e.g. PHPUnit classes)
