### PR TITLE
Fixes #3695: Markdown should not be included in the controller

### DIFF
--- a/classes/kohana/kodoc/markdown.php
+++ b/classes/kohana/kodoc/markdown.php
@@ -1,4 +1,10 @@
 <?php defined('SYSPATH') or die('No direct script access.');
+// Allowing for autoloading of Markdown if unit testing.
+if (defined("SUPPRESS_REQUEST"))
+{
+	require Kohana::find_file('vendor', 'markdown/markdown');
+}
+
 /**
  * Custom Markdown parser for Kohana documentation.
  *

--- a/classes/kohana/kodoc/markdown.php
+++ b/classes/kohana/kodoc/markdown.php
@@ -1,9 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');
-// Allowing for autoloading of Markdown if unit testing.
-if (defined("SUPPRESS_REQUEST"))
-{
-	require Kohana::find_file('vendor', 'markdown/markdown');
-}
+// Requiring markdown to protect against errors in different environments
+require Kohana::find_file('vendor', 'markdown/markdown');
 
 /**
  * Custom Markdown parser for Kohana documentation.


### PR DESCRIPTION
Autoloading of the Markdown class if Kohana is run from the command line. (e.g PHPUnit)
