### PR TITLE
Check if view exists before attempting to render it into the markdown doc

### DIFF
--- a/classes/kohana/kodoc/markdown.php
+++ b/classes/kohana/kodoc/markdown.php
@@ -152,18 +152,21 @@ class Kohana_Kodoc_Markdown extends MarkdownExtra_Parser {
 			{
 				list($search, $view) = $set;
 
-				try
+				if (Kohana::find_file('views', $view) !== FALSE)
 				{
-					$replace[$search] = View::factory($view)->render();
-				}
-				catch (Exception $e)
-				{
-					ob_start();
+					try
+					{
+						$replace[$search] = View::factory($view)->render();
+					}
+					catch (Exception $e)
+					{
+						ob_start();
 
-					// Capture the exception handler output and insert it instead
-					Kohana::exception_handler($e);
+						// Capture the exception handler output and insert it instead
+						Kohana::exception_handler($e);
 
-					$replace[$search] = ob_get_clean();
+						$replace[$search] = ob_get_clean();
+					}
 				}
 			}
 


### PR DESCRIPTION
This addresses this exception.  http://kohanaframework.org/3.2/guide/userguide/markdown

In accordance with the docs, "If the view is not found, no error or exception will be shown, the curly brackets and view name will simply remain there!"

I simply added a conditional to check if the view exists before rendering it. 
