### PR TITLE
Hide class prefixes other than Kohana_ in userguide - implements #3529

### DIFF
--- a/classes/kohana/kodoc.php
+++ b/classes/kohana/kodoc.php
@@ -57,15 +57,6 @@ class Kohana_Kodoc {
 	{
 		$classes = Kodoc::classes();
 
-		foreach ($classes as $class)
-		{
-			if (isset($classes['kohana_'.$class]))
-			{
-				// Remove extended classes
-				unset($classes['kohana_'.$class]);
-			}
-		}
-
 		ksort($classes);
 
 		$menu = array();
@@ -74,11 +65,18 @@ class Kohana_Kodoc {
 
 		foreach ($classes as $class)
 		{
+			if (Kodoc::is_transparent($class, $classes))
+			{
+				continue;
+			}
+
 			$class = Kodoc_Class::factory($class);
 
 			// Test if we should show this class
 			if ( ! Kodoc::show_class($class))
+			{
 				continue;
+			}
 
 			$link = HTML::anchor($route->uri(array('class' => $class->class->name)), $class->class->name);
 
@@ -166,13 +164,13 @@ class Kohana_Kodoc {
 
 		foreach ($list as $class)
 		{
-			$_class = new ReflectionClass($class);
-
-			if (stripos($_class->name, 'Kohana_') === 0)
+			// Skip transparent extension classes
+			if (Kodoc::is_transparent($class))
 			{
-				// Skip transparent extension classes
 				continue;
 			}
+
+			$_class = new ReflectionClass($class);
 
 			$methods = array();
 
@@ -180,10 +178,10 @@ class Kohana_Kodoc {
 			{
 				$declares = $_method->getDeclaringClass()->name;
 
-				if (stripos($declares, 'Kohana_') === 0)
+				// Remove the transparent prefix from declaring classes
+				if ($child = Kodoc::is_transparent($declares))
 				{
-					// Remove "Kohana_"
-					$declares = substr($declares, 7);
+					$declares = $child;
 				}
 
 				if ($declares === $_class->name OR $declares === "Core")
@@ -348,6 +346,72 @@ class Kohana_Kodoc {
 		}
 
 		return $show_this;
+	}
+
+	/**
+	 * Checks whether a class is a transparent extension class or not.
+	 *
+	 * This method takes an optional $classes parameter, a list of all defined
+	 * class names. If provided, the method will return false unless the extension
+	 * class exists. If not, the method will only check known transparent class
+	 * prefixes.
+	 *
+	 * [!!] The $classes parameter is expected to be a result from Kodoc::classes
+	 * and will therefore contain lowercased class names. When $classes is provided,
+	 * $class must also be lowercase, or an exception will be thrown.
+	 *
+	 * Transparent prefixes are defined in the userguide.php config file in
+	 * *lowercase*:
+	 *
+	 *     'transparent_prefixes' => array(
+	 *         'kohana' => true,
+	 *     );
+	 *
+	 * Module developers can therefore add their own transparent extension
+	 * namespaces and exclude them from the userguide.
+	 *          
+	 * @param string $class The name of the class to check for transparency
+	 * @param array $classes An optional list of all defined classes
+	 * @return false If this is not a transparent extension class 
+	 * @return string The name of the class that extends this (in the case provided)
+	 * @throws InvalidArgumentException If the $classes array is provided and the $class variable is not lowercase
+	 */
+	public static function is_transparent($class, $classes = NULL)
+	{
+		if ($classes AND ($class != strtolower($class)))
+		{
+			throw new InvalidArgumentException("Kodoc::is_transparent expects lowercase \$class when \$classes array is provided.");
+		}
+
+		static $transparent_prefixes = NULL;
+
+		if ( ! $transparent_prefixes)
+		{
+			$transparent_prefixes = Kohana::$config->load('userguide.transparent_prefixes');
+		}
+
+		// Hack for Kohana_Core, which doesn't follow convention
+		if ($class == 'Kohana_Core') 
+		{
+			return 'Kohana';
+		} 
+		elseif ($class == 'kohana_core') 
+		{
+			return 'kohana';
+		}
+
+		// For all others, split into the two elements of the class name
+		$segments = explode('_',$class,2);
+
+		$result = ((count($segments) == 2)
+		          AND (isset($transparent_prefixes[strtolower($segments[0])])));
+
+		if ($result AND $classes) 
+		{
+			$result = ($result AND isset($classes[$segments[1]]));
+		}
+
+		return $result ? $segments[1] : FALSE;
 	}
 
 

--- a/config/userguide.php
+++ b/config/userguide.php
@@ -27,5 +27,10 @@ return array
 			// Copyright message, shown in the footer for this module
 			'copyright' => '&copy; 2008–2011 Kohana Team',
 		)	
+	),
+
+	// Set transparent class name segments
+	'transparent_prefixes' => array(
+		'kohana' => TRUE,
 	)
 );

--- a/guide/userguide/adding.md
+++ b/guide/userguide/adding.md
@@ -24,6 +24,15 @@ First, copy this config and place in it `<module>/config/userguide.php`, replaci
 				// Copyright message, shown in the footer for this module
 				'copyright' => '&copy; 2010–2011 <Your Name>',
 			)	
+		),
+
+		/*
+		 * If you use transparent extension outside the Kohana_ namespace,
+		 * add your class prefix here (in lowercase).
+		 * For example, if you use Modulename_<class_name>, then you would define:
+		 */
+		'transparent_prefixes' => array(
+			'modulename' => true,
 		)
 	);
 

--- a/tests/userguide/KoDocTest.php
+++ b/tests/userguide/KoDocTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests for the Kodoc userguide class
+ * @group userguide
+ */
+class KodocTest extends Kohana_Unittest_TestCase
+{
+	const EXPECT_EXCEPTION = -1;
+
+	/**
+	 * Provides test data for test_transparent_classes
+	 * @return array
+	 */
+	public function provider_transparent_classes()
+	{
+		return array(
+			//Kohana_Core is a special case
+			array('kohana','kohana_core',null),
+			array('Controller_Template','Kohana_Controller_Template',null),
+			array('controller_template','kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template',
+			                                                               'controller_template'=>'controller_template')),
+		array(false,'kohana_controller_template',array('kohana_controller_template'=>'kohana_controller_template')),
+		array(false,'Controller_Template',null),
+		array(self::EXPECT_EXCEPTION,'Kohana_Controller_Template',array('kohana_controller_template'=>'kohana_controller_template'))
+		);
+	}
+
+	/**
+	 * Tests Kodoc::is_transparent
+	 *
+	 * Checks that a selection of transparent and non-transparent classes give expected results
+	 *
+	 * @group userguide.feat3529-configurable-transparent-classes
+	 * @dataProvider provider_transparent_classes
+	 * @param mixed $expected
+	 * @param string $class
+	 * @param array $classes
+	 */
+	public function test_transparent_classes($expected, $class, $classes)
+	{
+		try
+		{
+			$result = Kodoc::is_transparent($class, $classes);
+
+			if ($expected == self::EXPECT_EXCEPTION)
+			{
+				$this->fail('Kodoc::is_transparent did not throw an expected InvalidArgumentException');
+			} 
+			else 
+			{
+				$this->assertSame($expected,$result);
+			}
+		} catch (InvalidArgumentException $e) {
+			if ($expected != self::EXPECT_EXCEPTION)
+			{
+				// We weren't expecting that
+				$this->fail('Kodoc::is_transparent threw unexpected InvalidArgumentException with message '.$e->getMessage());
+			}
+		}
+
+	}
+}

--- a/views/userguide/api/class.php
+++ b/views/userguide/api/class.php
@@ -5,6 +5,13 @@
 	<?php endforeach; ?>
 </h1>
 
+<?php if ($child = $doc->is_transparent($doc->class->name)):?>
+<p class="note">
+This class is a transparent base class for <?php echo HTML::anchor($route->uri(array('class'=>$child)),$child) ?> and
+should not be accessed directly.
+</p>
+<?php endif;?>
+
 <?php echo $doc->description ?>
 
 <?php if ($doc->tags): ?>


### PR DESCRIPTION
Userguide now uses Kodoc::is_transparent() method to determine whether a class is a transparent extension class or not, allowing developers to use their own prefixes for classes and keep them out of the kohana core namespace, without losing the ability to hide the implementing classes in the userguide.

Previously only classes beginning Kohana_ were hidden, but the prefixes can now be configured.

This implements http://dev.kohanaframework.org/issues/3529 and is now updated for 3.2/develop
