### PR TITLE
Display user documentation with disabled API access

### DIFF
--- a/views/userguide/template.php
+++ b/views/userguide/template.php
@@ -25,9 +25,11 @@
 					<li class="guide first">
 						<a href="<?php echo Route::url('docs/guide') ?>"><?php echo __('User Guide') ?></a>
 					</li>
+					<?php if (Kohana::$config->load('userguide.api_browser')): ?>
 					<li class="api">
 						<a href="<?php echo Route::url('docs/api') ?>"><?php echo __('API Browser') ?></a>
 					</li>
+					<?php endif ?>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
If you disable userguide.api_browser, there's an error displayed when visiting /guide:

Kohana_Exception [ 0 ]: The requested route does not exist: docs/api

This _fix_ allows a user to display the user guide while disabling access to the API documentation.
