### PR TITLE
#4428: Allow comment tags to span multiple lines

### DIFF
--- a/classes/Kohana/Kodoc.php
+++ b/classes/Kohana/Kodoc.php
@@ -224,7 +224,7 @@ class Kohana_Kodoc {
 			$line = preg_replace('/^\s*\* ?/m', '', $line);
 
 			// Search this line for a tag
-			if (preg_match('/^@(\S+)(?:\s*(.+))?$/', $line, $matches))
+			if (preg_match('/^@(\S+)\s*(.+)?$/', $line, $matches))
 			{
 				// This is a tag line
 				unset($comment[$i]);

--- a/classes/Kohana/Kodoc.php
+++ b/classes/Kohana/Kodoc.php
@@ -256,6 +256,7 @@ class Kohana_Kodoc {
 						$text = HTML::anchor($route->uri(array('class' => $text)), $text);
 					}
 					break;
+				case 'see':
 				case 'uses':
 					if (preg_match('/^'.Kodoc::$regex_class_member.'/', $text, $matches))
 					{

--- a/classes/Kohana/Kodoc.php
+++ b/classes/Kohana/Kodoc.php
@@ -212,79 +212,106 @@ class Kohana_Kodoc {
 		// Normalize all new lines to \n
 		$comment = str_replace(array("\r\n", "\n"), "\n", $comment);
 
-		// Remove the phpdoc open/close tags and split
-		$comment = array_slice(explode("\n", $comment), 1, -1);
+		// Split into lines while capturing without leading whitespace
+		preg_match_all('/^\s*\* ?(.*)\n/m', $comment, $lines);
+
+		$route = Route::get('docs/api');
 
 		// Tag content
 		$tags = array();
 
-		foreach ($comment as $i => $line)
+		/**
+		 * Process a tag and add it to $tags
+		 *
+		 * @param   string  $tag    Name of the tag without @
+		 * @param   string  $text   Content of the tag
+		 * @return  void
+		 */
+		$add_tag = function($tag, $text) use ($route, &$tags)
 		{
-			// Remove all leading whitespace
-			$line = preg_replace('/^\s*\* ?/m', '', $line);
+			switch ($tag)
+			{
+				case 'license':
+					if (strpos($text, '://') !== FALSE)
+					{
+						// Convert the lincense into a link
+						$text = HTML::anchor($text);
+					}
+					break;
+				case 'link':
+					$text = preg_split('/\s+/', $text, 2);
+					$text = HTML::anchor($text[0], isset($text[1]) ? $text[1] : $text[0]);
+					break;
+				case 'copyright':
+					// Convert the copyright symbol
+					$text = str_replace('(c)', '&copy;', $text);
+					break;
+				case 'throws':
+					if (preg_match('/^(\w+)\W(.*)$/D', $text, $matches))
+					{
+						$text = HTML::anchor($route->uri(array('class' => $matches[1])), $matches[1]).' '.$matches[2];
+					}
+					else
+					{
+						$text = HTML::anchor($route->uri(array('class' => $text)), $text);
+					}
+					break;
+				case 'uses':
+					if (preg_match('/^'.Kodoc::$regex_class_member.'/', $text, $matches))
+					{
+						$text = Kodoc::link_class_member($matches);
+					}
+					break;
+				// Don't show @access lines, they are shown elsewhere
+				case 'access':
+					return;
+			}
 
+			// Add the tag
+			$tags[$tag][] = $text;
+		};
+
+		$comment = $tag = null;
+		$end = count($lines[1]) - 1;
+
+		foreach ($lines[1] as $i => $line)
+		{
 			// Search this line for a tag
 			if (preg_match('/^@(\S+)\s*(.+)?$/', $line, $matches))
 			{
-				// This is a tag line
-				unset($comment[$i]);
-
-				$name = $matches[1];
-				$text = isset($matches[2]) ? $matches[2] : '';
-
-				switch ($name)
+				if ($tag)
 				{
-					case 'license':
-						if (strpos($text, '://') !== FALSE)
-						{
-							// Convert the lincense into a link
-							$text = HTML::anchor($text);
-						}
-					break;
-					case 'link':
-						$text = preg_split('/\s+/', $text, 2);
-						$text = HTML::anchor($text[0], isset($text[1]) ? $text[1] : $text[0]);
-					break;
-					case 'copyright':
-						if (strpos($text, '(c)') !== FALSE)
-						{
-							// Convert the copyright sign
-							$text = str_replace('(c)', '&copy;', $text);
-						}
-					break;
-					case 'throws':
-						if (preg_match('/^(\w+)\W(.*)$/', $text, $matches))
-						{
-							$text = HTML::anchor(Route::get('docs/api')->uri(array('class' => $matches[1])), $matches[1]).' '.$matches[2];
-						}
-						else
-						{
-							$text = HTML::anchor(Route::get('docs/api')->uri(array('class' => $text)), $text);
-						}
-					break;
-					case 'uses':
-						if (preg_match('/^'.Kodoc::$regex_class_member.'$/i', $text, $matches))
-						{
-							$text = Kodoc::link_class_member($matches);
-						}
-					break;
-					// Don't show @access lines, they are shown elsewhere
-					case 'access':
-						continue 2;
+					// Previous tag is finished
+					$add_tag($tag, $text);
 				}
 
-				// Add the tag
-				$tags[$name][] = $text;
+				$tag = $matches[1];
+				$text = isset($matches[2]) ? $matches[2] : '';
+
+				if ($i === $end)
+				{
+					// No more lines
+					$add_tag($tag, $text);
+				}
+			}
+			elseif ($tag)
+			{
+				// This is the continuation of the previous tag
+				$text .= "\n".$line;
+
+				if ($i === $end)
+				{
+					// No more lines
+					$add_tag($tag, $text);
+				}
 			}
 			else
 			{
-				// Overwrite the comment line
-				$comment[$i] = (string) $line;
+				$comment .= "\n".$line;
 			}
 		}
 
-		// Concat the comment lines back to a block of text
-		if ($comment = trim(implode("\n", $comment)))
+		if ($comment = trim($comment, "\n"))
 		{
 			// Parse the comment with Markdown
 			$comment = Kodoc_Markdown::markdown($comment);

--- a/classes/Kohana/Kodoc/Method.php
+++ b/classes/Kohana/Kodoc/Method.php
@@ -68,7 +68,7 @@ class Kohana_Kodoc_Method extends Kodoc {
 
 				if (isset($tags['param'][$i]))
 				{
-					preg_match('/^(\S+)(?:\s*(?:\$'.$param->name.'\s*)?(.+))?$/', $tags['param'][$i], $matches);
+					preg_match('/^(\S+)(?:\s*(?:\$'.$param->name.'\s*)?(.+))?$/s', $tags['param'][$i], $matches);
 
 					$param->type = $matches[1];
 

--- a/classes/Kohana/Kodoc/Method/Param.php
+++ b/classes/Kohana/Kodoc/Method/Param.php
@@ -83,7 +83,7 @@ class Kohana_Kodoc_Method_Param extends Kodoc {
 
 		if ($this->description)
 		{
-			$display .= '<span class="param" title="'.$this->description.'">$'.$this->name.'</span> ';
+			$display .= '<span class="param" title="'.preg_replace('/\s+/', ' ', $this->description).'">$'.$this->name.'</span> ';
 		}
 		else
 		{

--- a/classes/Kohana/Kodoc/Property.php
+++ b/classes/Kohana/Kodoc/Property.php
@@ -50,7 +50,7 @@ class Kohana_Kodoc_Property extends Kodoc {
 
 		if (isset($tags['var']))
 		{
-			if (preg_match('/^(\S*)(?:\s*(.+?))?$/', $tags['var'][0], $matches))
+			if (preg_match('/^(\S*)(?:\s*(.+?))?$/s', $tags['var'][0], $matches))
 			{
 				$this->type = $matches[1];
 

--- a/tests/KodocTest.php
+++ b/tests/KodocTest.php
@@ -208,7 +208,16 @@ COMMENT
  */
 COMMENT
 ,
-				array('', array('see' => array('MyClass'))),
+				array(
+					'',
+					array(
+						'see' => array(
+							'<a href="'.URL::site(
+								$route_api->uri(array('class' => 'MyClass'))
+							).'">MyClass</a>',
+						),
+					),
+				),
 			),
 			array(
 <<<'COMMENT'
@@ -217,7 +226,16 @@ COMMENT
  */
 COMMENT
 ,
-				array('', array('see' => array('MyClass::method()'))),
+				array(
+					'',
+					array(
+						'see' => array(
+							'<a href="'.URL::site(
+								$route_api->uri(array('class' => 'MyClass')).'#method'
+							).'">MyClass::method()</a>',
+						),
+					),
+				),
 			),
 			array(
 <<<'COMMENT'

--- a/tests/KodocTest.php
+++ b/tests/KodocTest.php
@@ -82,6 +82,15 @@ COMMENT
 					array('tag' => array('Content')),
 				),
 			),
+			array(
+<<<'COMMENT'
+/**
+ * @trailingspace 
+ */
+COMMENT
+,
+				array('', array('trailingspace' => array(''))),
+			),
 		);
 	}
 

--- a/tests/KodocTest.php
+++ b/tests/KodocTest.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * @package    Kohana/Userguide
+ * @author     Kohana Team
+ * @copyright  (c) 2012 Kohana Team
+ * @license    http://kohanaframework.org/license
+ */
+class Kohana_KodocTest extends PHPUnit_Framework_TestCase
+{
+	public function provider_parse_basic()
+	{
+		return array(
+			array(
+<<<'COMMENT'
+/**
+ * Description
+ */
+COMMENT
+,
+				array("<p>Description</p>\n", array()),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * Description spanning
+ * multiple lines
+ */
+COMMENT
+,
+				array("<p>Description spanning\nmultiple lines</p>\n", array()),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * Description including
+ *
+ *     a code block
+ */
+COMMENT
+,
+				array("<p>Description including</p>\n\n<pre><code>a code block\n</code></pre>\n", array()),
+			),
+			array(
+<<<'COMMENT'
+	/**
+	 * Indented
+	 */
+COMMENT
+,
+				array("<p>Indented</p>\n", array()),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @tag Content
+ */
+COMMENT
+,
+				array('', array('tag' => array('Content'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @tag Multiple
+ * @tag Tags
+ */
+COMMENT
+,
+				array('', array('tag' => array('Multiple', 'Tags'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * Description with tag
+ * @tag Content
+ */
+COMMENT
+,
+				array(
+					"<p>Description with tag</p>\n",
+					array('tag' => array('Content')),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @covers  Kohana_Kodoc::parse
+	 *
+	 * @dataProvider    provider_parse_basic
+	 *
+	 * @param   string  $comment    Argument to the method
+	 * @param   array   $expected   Expected result
+	 */
+	public function test_parse_basic($comment, $expected)
+	{
+		$this->assertSame($expected, Kodoc::parse($comment));
+	}
+
+	public function provider_parse_tags()
+	{
+		$route_api = Route::get('docs/api');
+
+		return array(
+			array(
+<<<'COMMENT'
+/**
+ * @access public
+ */
+COMMENT
+,
+				array('', array()),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @copyright Some plain text
+ */
+COMMENT
+,
+				array('', array('copyright' => array('Some plain text'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @copyright (c) 2012 Kohana Team
+ */
+COMMENT
+,
+				array('', array('copyright' => array('&copy; 2012 Kohana Team'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @license Kohana
+ */
+COMMENT
+,
+				array('', array('license' => array('Kohana'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @license http://kohanaframework.org/license
+ */
+COMMENT
+,
+				array('', array('license' => array('<a href="http://kohanaframework.org/license">http://kohanaframework.org/license</a>'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @link http://kohanaframework.org
+ */
+COMMENT
+,
+				array('', array('link' => array('<a href="http://kohanaframework.org">http://kohanaframework.org</a>'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @link http://kohanaframework.org Description
+ */
+COMMENT
+,
+				array('', array('link' => array('<a href="http://kohanaframework.org">Description</a>'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @see MyClass
+ */
+COMMENT
+,
+				array('', array('see' => array('MyClass'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @see MyClass::method()
+ */
+COMMENT
+,
+				array('', array('see' => array('MyClass::method()'))),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @throws Exception
+ */
+COMMENT
+,
+				array(
+					'',
+					array(
+						'throws' => array(
+							'<a href="'.URL::site(
+								$route_api->uri(array('class' => 'Exception'))
+							).'">Exception</a>',
+						),
+					),
+				),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @throws Exception During failure
+ */
+COMMENT
+,
+				array(
+					'',
+					array(
+						'throws' => array(
+							'<a href="'.URL::site(
+								$route_api->uri(array('class' => 'Exception'))
+							).'">Exception</a> During failure',
+						),
+					),
+				),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @uses MyClass
+ */
+COMMENT
+,
+				array(
+					'',
+					array(
+						'uses' => array(
+							'<a href="'.URL::site(
+								$route_api->uri(array('class' => 'MyClass'))
+							).'">MyClass</a>',
+						),
+					),
+				),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @uses MyClass::method()
+ */
+COMMENT
+,
+				array(
+					'',
+					array(
+						'uses' => array(
+							'<a href="'.URL::site(
+								$route_api->uri(array('class' => 'MyClass')).'#method'
+							).'">MyClass::method()</a>',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @covers  Kohana_Kodoc::parse
+	 *
+	 * @dataProvider    provider_parse_tags
+	 *
+	 * @param   string  $comment    Argument to the method
+	 * @param   array   $expected   Expected result
+	 */
+	public function test_parse_tags($comment, $expected)
+	{
+		$this->assertSame($expected, Kodoc::parse($comment));
+	}
+}

--- a/tests/KodocTest.php
+++ b/tests/KodocTest.php
@@ -91,6 +91,32 @@ COMMENT
 ,
 				array('', array('trailingspace' => array(''))),
 			),
+			array(
+<<<'COMMENT'
+/**
+ * @tag Content that spans
+ * multiple lines
+ */
+COMMENT
+,
+				array(
+					'',
+					array('tag' => array("Content that spans\nmultiple lines")),
+				),
+			),
+			array(
+<<<'COMMENT'
+/**
+ * @tag Content that spans
+ *    multiple lines indented
+ */
+COMMENT
+,
+				array(
+					'',
+					array('tag' => array("Content that spans\n   multiple lines indented")),
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
Tags can now span multiple lines according to the phpdoc format. Tests included.
