### PR TITLE
Improve menu performance in API browser

### DIFF
--- a/classes/Controller/Userguide.php
+++ b/classes/Controller/Userguide.php
@@ -210,7 +210,7 @@ class Controller_Userguide extends Controller_Template {
 			$this->template->title = $class;
 
 			$this->template->content = View::factory('userguide/api/class')
-				->set('doc', Kodoc::factory($class))
+				->set('doc', $_class)
 				->set('route', $this->request->route());
 		}
 
@@ -219,9 +219,6 @@ class Controller_Userguide extends Controller_Template {
 
 		// Bind the breadcrumb
 		$this->template->bind('breadcrumb', $breadcrumb);
-
-		// Get the docs URI
-		$guide = Route::get('docs/guide');
 
 		// Add the breadcrumb
 		$breadcrumb = array();

--- a/classes/Kohana/Kodoc.php
+++ b/classes/Kohana/Kodoc.php
@@ -258,10 +258,14 @@ class Kohana_Kodoc {
 	/**
 	 * Parse a comment to extract the description and the tags
 	 *
+	 * [!!] Converting the output to HTML in this method is deprecated in 3.3
+	 *
 	 * @param   string  $comment    The DocBlock to parse
+	 * @param   boolean $html       Whether or not to convert the return values
+	 *   to HTML (deprecated)
 	 * @return  array   array(string $description, array $tags)
 	 */
-	public static function parse($comment)
+	public static function parse($comment, $html = TRUE)
 	{
 		// Normalize all new lines to \n
 		$comment = str_replace(array("\r\n", "\n"), "\n", $comment);
@@ -279,13 +283,18 @@ class Kohana_Kodoc {
 		 * @param   string  $text   Content of the tag
 		 * @return  void
 		 */
-		$add_tag = function($tag, $text) use (&$tags)
+		$add_tag = function($tag, $text) use ($html, &$tags)
 		{
 			// Don't show @access lines, they are shown elsewhere
 			if ($tag !== 'access')
 			{
+				if ($html)
+				{
+					$text = Kodoc::format_tag($tag, $text);
+				}
+
 				// Add the tag
-				$tags[$tag][] = Kodoc::format_tag($tag, $text);
+				$tags[$tag][] = $text;
 			}
 		};
 
@@ -329,7 +338,9 @@ class Kohana_Kodoc {
 			}
 		}
 
-		if ($comment = trim($comment, "\n"))
+		$comment = trim($comment, "\n");
+
+		if ($comment AND $html)
 		{
 			// Parse the comment with Markdown
 			$comment = Kodoc_Markdown::markdown($comment);

--- a/classes/Kohana/Kodoc/Class.php
+++ b/classes/Kohana/Kodoc/Class.php
@@ -57,13 +57,7 @@ class Kohana_Kodoc_Class extends Kodoc {
 			$this->modifiers = '<small>'.implode(' ', Reflection::getModifierNames($modifiers)).'</small> ';
 		}
 
-		if ($constants = $this->class->getConstants())
-		{
-			foreach ($constants as $name => $value)
-			{
-				$this->constants[$name] = Debug::vars($value);
-			}
-		}
+		$this->constants = $this->class->getConstants();
 
 		// If ReflectionClass::getParentClass() won't work if the class in 
 		// question is an interface
@@ -109,6 +103,23 @@ class Kohana_Kodoc_Class extends Kodoc {
 				$this->description = Kodoc_Markdown::markdown($warning).$this->description;
 			}
 		}
+	}
+
+	/**
+	 * Gets the constants of this class as HTML.
+	 *
+	 * @return  array
+	 */
+	public function constants()
+	{
+		$result = array();
+
+		foreach ($this->constants as $name => $value)
+		{
+			$result[$name] = Debug::vars($value);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/views/userguide/api/class.php
+++ b/views/userguide/api/class.php
@@ -71,7 +71,7 @@ Class is not declared in a file, it is probably an internal <?php echo html::anc
 <div class="constants">
 <h1 id="constants"><?php echo __('Constants'); ?></h1>
 <dl>
-<?php foreach ($doc->constants as $name => $value): ?>
+<?php foreach ($doc->constants() as $name => $value): ?>
 <dt><h4 id="constant:<?php echo $name ?>"><?php echo $name ?></h4></dt>
 <dd><?php echo $value ?></dd>
 <?php endforeach; ?>

--- a/views/userguide/api/class.php
+++ b/views/userguide/api/class.php
@@ -5,11 +5,11 @@
 	<?php endforeach; ?>
 </h1>
 
-<?php echo $doc->description ?>
+<?php echo $doc->description() ?>
 
 <?php if ($doc->tags): ?>
 <dl class="tags">
-<?php foreach ($doc->tags as $name => $set): ?>
+<?php foreach ($doc->tags() as $name => $set): ?>
 <dt><?php echo $name ?></dt>
 <?php foreach ($set as $tag): ?>
 <dd><?php echo $tag ?></dd>


### PR DESCRIPTION
`Kodoc::menu()` created instances of `Kodoc_Class` so it could read the class' `@package` tags to [decide if the class should be shown or not](https://github.com/kohana/userguide/blob/3e9de2620adebe5ded28939ac3f26e0fd8358773/classes/Kohana/Kodoc.php#L77-81). The `Kodoc_Class` constructor rendered the description, contents and tags to HTML, even though they weren't used.

In these commits, I've moved this rendering into methods called by the view template, saving hundreds of calls to Markdown and other formatting functions. On my local machine, with only a few modules enabled, this allows the API table of contents to render in about half the time.
