### PR TITLE
3.3/feature/3529 configurable transparent class prefixes

### DIFF
--- a/classes/Kohana/Kodoc.php
+++ b/classes/Kohana/Kodoc.php
@@ -66,17 +66,13 @@ class Kohana_Kodoc {
 		foreach ($classes as $class)
 		{
 			if (Kodoc::is_transparent($class, $classes))
-			{
 				continue;
-			}
 
 			$class = Kodoc_Class::factory($class);
 
 			// Test if we should show this class
 			if ( ! Kodoc::show_class($class))
-			{
 				continue;
-			}
 
 			$link = HTML::anchor($route->uri(array('class' => $class->class->name)), $class->class->name);
 
@@ -167,9 +163,7 @@ class Kohana_Kodoc {
 		{
 			// Skip transparent extension classes
 			if (Kodoc::is_transparent($class))
-			{
 				continue;
-			}
 
 			$_class = new ReflectionClass($class);
 
@@ -438,25 +432,34 @@ class Kohana_Kodoc {
 			$transparent_prefixes = Kohana::$config->load('userguide.transparent_prefixes');
 		}
 
-		// Hack for Kohana_Core, which doesn't follow convention
-		if ($class == 'Kohana_Core') 
-		{
-			return 'Kohana';
-		} 
-
-		// For all others, split into the two elements of the class name
+		// Split the class name at the first underscore
 		$segments = explode('_',$class,2);
 
-		$result = ((count($segments) == 2)
-		          AND (isset($transparent_prefixes[$segments[0]])));
-
-		// It is only a transparent class if the unprefixed class also exists
-		if ($result AND $classes) 
+		if ((count($segments) == 2) AND (isset($transparent_prefixes[$segments[0]])))
 		{
-			$result = ($result AND isset($classes[$segments[1]]));
+			if ($segments[1] === 'Core')
+			{
+				// Cater for Module extends Module_Core naming
+				$child_class = $segments[0];
+			}
+			else
+			{
+				// Cater for Foo extends Module_Foo naming
+				$child_class = $segments[1];
+			}
+			
+			// It is only a transparent class if the unprefixed class also exists
+			if ($classes AND ! isset($classes[$child_class]))
+				return FALSE;
+			
+			// Return the name of the child class
+			return $child_class;
 		}
-
-		return $result ? $segments[1] : FALSE;
+		else
+		{
+			// Not a transparent class
+			return FALSE;
+		}
 	}
 
 

--- a/classes/Kohana/Kodoc.php
+++ b/classes/Kohana/Kodoc.php
@@ -57,15 +57,6 @@ class Kohana_Kodoc {
 	{
 		$classes = Kodoc::classes();
 
-		foreach ($classes as $class)
-		{
-			if (isset($classes['kohana_'.$class]))
-			{
-				// Remove extended classes
-				unset($classes['kohana_'.$class]);
-			}
-		}
-
 		ksort($classes);
 
 		$menu = array();
@@ -74,11 +65,18 @@ class Kohana_Kodoc {
 
 		foreach ($classes as $class)
 		{
+			if (Kodoc::is_transparent($class, $classes))
+			{
+				continue;
+			}
+
 			$class = Kodoc_Class::factory($class);
 
 			// Test if we should show this class
 			if ( ! Kodoc::show_class($class))
+			{
 				continue;
+			}
 
 			$link = HTML::anchor($route->uri(array('class' => $class->class->name)), $class->class->name);
 
@@ -167,13 +165,13 @@ class Kohana_Kodoc {
 
 		foreach ($list as $class)
 		{
-			$_class = new ReflectionClass($class);
-
-			if (stripos($_class->name, 'Kohana_') === 0)
+			// Skip transparent extension classes
+			if (Kodoc::is_transparent($class))
 			{
-				// Skip transparent extension classes
 				continue;
 			}
+
+			$_class = new ReflectionClass($class);
 
 			$methods = array();
 
@@ -181,10 +179,10 @@ class Kohana_Kodoc {
 			{
 				$declares = $_method->getDeclaringClass()->name;
 
-				if (stripos($declares, 'Kohana_') === 0)
+				// Remove the transparent prefix from declaring classes
+				if ($child = Kodoc::is_transparent($declares))
 				{
-					// Remove "Kohana_"
-					$declares = substr($declares, 7);
+					$declares = $child;
 				}
 
 				if ($declares === $_class->name OR $declares === "Core")
@@ -405,6 +403,60 @@ class Kohana_Kodoc {
 		}
 
 		return $show_this;
+	}
+
+	/**
+	 * Checks whether a class is a transparent extension class or not.
+	 *
+	 * This method takes an optional $classes parameter, a list of all defined
+	 * class names. If provided, the method will return false unless the extension
+	 * class exists. If not, the method will only check known transparent class
+	 * prefixes.
+	 *
+	 * Transparent prefixes are defined in the userguide.php config file:
+	 *
+	 *     'transparent_prefixes' => array(
+	 *         'Kohana' => TRUE,
+	 *     );
+	 *
+	 * Module developers can therefore add their own transparent extension
+	 * namespaces and exclude them from the userguide.
+	 *          
+	 * @param string $class The name of the class to check for transparency
+	 * @param array $classes An optional list of all defined classes
+	 * @return false If this is not a transparent extension class 
+	 * @return string The name of the class that extends this (in the case provided)
+	 * @throws InvalidArgumentException If the $classes array is provided and the $class variable is not lowercase
+	 */
+	public static function is_transparent($class, $classes = NULL)
+	{
+
+		static $transparent_prefixes = NULL;
+
+		if ( ! $transparent_prefixes)
+		{
+			$transparent_prefixes = Kohana::$config->load('userguide.transparent_prefixes');
+		}
+
+		// Hack for Kohana_Core, which doesn't follow convention
+		if ($class == 'Kohana_Core') 
+		{
+			return 'Kohana';
+		} 
+
+		// For all others, split into the two elements of the class name
+		$segments = explode('_',$class,2);
+
+		$result = ((count($segments) == 2)
+		          AND (isset($transparent_prefixes[$segments[0]])));
+
+		// It is only a transparent class if the unprefixed class also exists
+		if ($result AND $classes) 
+		{
+			$result = ($result AND isset($classes[$segments[1]]));
+		}
+
+		return $result ? $segments[1] : FALSE;
 	}
 
 

--- a/config/userguide.php
+++ b/config/userguide.php
@@ -27,5 +27,10 @@ return array
 			// Copyright message, shown in the footer for this module
 			'copyright' => '&copy; 2008–2012 Kohana Team',
 		)	
+	),
+
+	// Set transparent class name segments
+	'transparent_prefixes' => array(
+		'Kohana' => TRUE,
 	)
 );

--- a/guide/userguide/adding.md
+++ b/guide/userguide/adding.md
@@ -24,6 +24,15 @@ First, copy this config and place in it `<module>/config/userguide.php`, replaci
 				// Copyright message, shown in the footer for this module
 				'copyright' => '&copy; 2010–2011 <Your Name>',
 			)	
+		),
+
+		/*
+		 * If you use transparent extension outside the Kohana_ namespace,
+		 * add your class prefix here (in lowercase).
+		 * For example, if you use Modulename_<class_name>, then you would define:
+		 */
+		'transparent_prefixes' => array(
+			'modulename' => true,
 		)
 	);
 

--- a/guide/userguide/adding.md
+++ b/guide/userguide/adding.md
@@ -28,11 +28,16 @@ First, copy this config and place in it `<module>/config/userguide.php`, replaci
 
 		/*
 		 * If you use transparent extension outside the Kohana_ namespace,
-		 * add your class prefix here (in lowercase).
-		 * For example, if you use Modulename_<class_name>, then you would define:
+		 * add your class prefix here. Both common Kohana naming conventions are
+		 * excluded: 
+		 *   - Modulename extends Modulename_Core
+		 *   - Foo extends Modulename_Foo
+		 * 
+		 * For example, if you use Modulename_<class_name> for your base classes
+		 * then you would define:
 		 */
 		'transparent_prefixes' => array(
-			'modulename' => true,
+			'Modulename' => TRUE,
 		)
 	);
 

--- a/tests/KodocTest.php
+++ b/tests/KodocTest.php
@@ -354,7 +354,7 @@ COMMENT
 	 *
 	 * Checks that a selection of transparent and non-transparent classes give expected results
 	 *
-	 * @group userguide.feat3529-configurable-transparent-classes
+	 * @group kohana.userguide.3529-configurable-transparent-classes
 	 * @dataProvider provider_transparent_classes
 	 * @param mixed $expected
 	 * @param string $class

--- a/tests/KodocTest.php
+++ b/tests/KodocTest.php
@@ -328,4 +328,41 @@ COMMENT
 	{
 		$this->assertSame($expected, Kodoc::parse($comment));
 	}
+	
+	/**
+	 * Provides test data for test_transparent_classes
+	 * @return array
+	 */
+	public function provider_transparent_classes()
+	{
+		return array(
+			// Kohana_Core is a special case
+			array('Kohana','Kohana_Core',NULL),
+			array('Controller_Template','Kohana_Controller_Template',NULL),
+			array('Controller_Template','Kohana_Controller_Template',
+				array('Kohana_Controller_Template'=>'Kohana_Controller_Template',
+					'Controller_Template'=>'Controller_Template')
+			),
+			array(FALSE,'Kohana_Controller_Template',
+				array('Kohana_Controller_Template'=>'Kohana_Controller_Template')),
+			array(FALSE,'Controller_Template',NULL),
+		);
+	}
+
+	/**
+	 * Tests Kodoc::is_transparent
+	 *
+	 * Checks that a selection of transparent and non-transparent classes give expected results
+	 *
+	 * @group userguide.feat3529-configurable-transparent-classes
+	 * @dataProvider provider_transparent_classes
+	 * @param mixed $expected
+	 * @param string $class
+	 * @param array $classes
+	 */
+	public function test_transparent_classes($expected, $class, $classes)
+	{
+		$result = Kodoc::is_transparent($class, $classes);
+		$this->assertSame($expected,$result);
+	}
 }

--- a/views/userguide/api/class.php
+++ b/views/userguide/api/class.php
@@ -5,6 +5,13 @@
 	<?php endforeach; ?>
 </h1>
 
+<?php if ($child = $doc->is_transparent($doc->class->name)):?>
+<p class="note">
+This class is a transparent base class for <?php echo HTML::anchor($route->uri(array('class'=>$child)),$child) ?> and
+should not be accessed directly.
+</p>
+<?php endif;?>
+
 <?php echo $doc->description() ?>
 
 <?php if ($doc->tags): ?>


### PR DESCRIPTION
Userguide now uses Kodoc::is_transparent() method to determine whether
a class is a transparent extension class or not, allowing developers to
use their own prefixes for classes and keep them out of the kohana core
namespace, without losing the ability to hide the implementing classes in
the userguide.

Previously only classes beginning Kohana_ were hidden, but the prefixes
can now be configured.

This has now been updated for 3.3
