### PR TITLE
3.3/feature/3486 show class interfaces

### DIFF
--- a/views/userguide/api/class.php
+++ b/views/userguide/api/class.php
@@ -5,6 +5,18 @@
 	<?php endforeach; ?>
 </h1>
 
+<?php if ($interfaces = $doc->class->getInterfaceNames()):?>
+<p class="interfaces"><small>
+Implements:
+<?php
+for ($i = 0, $split = false, $count = count($interfaces); $i < $count; $i++, $split=" | ")
+{
+    echo $split . HTML::anchor($route->uri(array('class' => $interfaces[$i])),$interfaces[$i]);
+}
+?></small>
+</p>
+<?php endif;?>
+
 <?php echo $doc->description() ?>
 
 <?php if ($doc->tags): ?>


### PR DESCRIPTION
Show a basic list of the interfaces a class implements below the extension path in userguide - replaces previous pull for 3.2.

References http://dev.kohanaframework.org/issues/3486
