### PR TITLE
3.2/feature/4476 allow md extension

### DIFF
--- a/classes/controller/userguide.php
+++ b/classes/controller/userguide.php
@@ -293,8 +293,30 @@ class Controller_Userguide extends Controller_Template {
 		return parent::after();
 	}
 
+	/**
+	 * Locates the appropriate markdown file for a given guide page. Page URLS
+	 * can be specified in one of three forms:
+	 *
+	 *  * userguide/adding
+	 *  * userguide/adding.md
+	 *  * userguide/adding.markdown
+	 *
+	 * In every case, the userguide will search the cascading file system paths
+	 * for the file guide/userguide/adding.md.
+	 *
+	 * @param string $page The relative URL of the guide page
+	 * @return string
+	 */
 	public function file($page)
 	{
+
+		// Strip optional .md or .markdown suffix from the passed filename
+		$info = pathinfo($page);
+		if (isset($info['extension'])
+			AND (($info['extension'] === 'md') OR ($info['extension'] === 'markdown')))
+		{
+			$page = $info['dirname'].DIRECTORY_SEPARATOR.$info['filename'];
+		}
 		return Kohana::find_file('guide', $page, 'md');
 	}
 

--- a/guide/userguide/markdown.md
+++ b/guide/userguide/markdown.md
@@ -192,6 +192,8 @@ To link to page in a different module, prefix your url with `../` and the module
 
 **Images are also namespaced**, using `![Alt Text](imagename.jpg)` would look for `media/guide/<modulename>/imagename.jpg`.
 
+[!!] If you want your userguide pages to be browsable on github or similar sites outside Kohana's own userguide module, specify the optional .md file extension in your links
+
 ## API Links
 
 You can make links to the api browser by wrapping any class name in brackets.  You may also include a function name, or propery name to link to that specifically.  All of the following will link to the API browser:

--- a/tests/userguide/ControllerTest.php
+++ b/tests/userguide/ControllerTest.php
@@ -1,0 +1,45 @@
+<?php defined('SYSPATH') OR die('Kohana bootstrap needs to be included before tests run');
+
+/**
+ * Unit tests for internal methods of userguide controller
+ *
+ * @group kohana
+ * @group kohana.userguide
+ * @group kohana.userguide.controller
+ *
+ * @package    Kohana/Userguide
+ * @category   Tests
+ * @author     Kohana Team
+ * @copyright  (c) 2008-2012 Kohana Team
+ * @license    http://kohanaframework.org/license
+ */
+class Userguide_ControllerTest extends Unittest_TestCase
+{
+
+	public function provider_file_finds_markdown_files()
+	{
+		return array(
+			array('userguide/adding', 'guide/userguide/adding.md'),
+			array('userguide/adding.md', 'guide/userguide/adding.md'),
+			array('userguide/adding.markdown', 'guide/userguide/adding.md'),
+			array('userguide/does_not_exist.md', FALSE)
+		);
+	}
+
+	/**
+	 * @dataProvider provider_file_finds_markdown_files
+	 * @param string $page  Page name passed in the URL
+	 * @param string $expected_file  Expected result from Controller_Userguide::file
+	 */
+	public function test_file_finds_markdown_files($page, $expected_file)
+	{
+		$controller = $this->getMock('Controller_Userguide', array('__construct'), array(), '', FALSE);
+		$path = $controller->file($page);
+
+		// Only verify trailing segments to avoid problems if file overwritten in CFS
+		$expected_len = strlen($expected_file);
+		$file = substr($path, -$expected_len, $expected_len);
+
+		$this->assertEquals($expected_file, $file);
+	}
+}


### PR DESCRIPTION
Links to guide pages can now optionally include the .md suffix - eg `[My first page](my_first_page.md)` will now correctly map to the my_first_page.md file in your module's userguide. This allows guide files to be browsed on github as well as in the userguide.

See ticket: http://dev.kohanaframework.org/issues/4476
