### PR TITLE
Edits on Contributing page, casing mostly

### DIFF
--- a/guide/userguide/contributing.md
+++ b/guide/userguide/contributing.md
@@ -16,7 +16,7 @@ To quickly point out something that needs improvement, report a [bug report](htt
 
 If you want to contribute some changes, you can do so right from your browser without even knowing git!
 
-First create an account on [Github](https://github.com/signup/free).
+First create an account on [GitHub](https://github.com/signup/free).
 
 You will need to fork the module for the area you want to improve.  For example, to improve the [ORM documentation](../orm) fork <http://github.com/kohana/orm>.  To improve the [Kohana documentation](../kohana), fork <http://github.com/kohana/core>, etc.  So, find the module you want to improve and click on the Fork button in the top right.
 
@@ -34,26 +34,30 @@ After you have made your changes, send a pull request so your improvements can b
 
 Once your pull request has been accepted, you can delete your repository if you want.  Your commit will have been copied to the official branch.
 
-## If you know git
+## If you know Git
 
-**Short version**: Fork the module whose docs you wish to improve (e.g. `git://github.com/kohana/orm.git` or `git://github.com/kohana/core.git`), checkout the `3.2/develop` branch (for the 3.2 docs!), make changes, and then send a pull request.
+### Short version
 
-**Long version:**  (This still assumes you at least know your way around git, especially how submodules work.)
+Fork the module whose docs you wish to improve (e.g. `git://github.com/kohana/orm.git` or `git://github.com/kohana/core.git`), checkout the `3.2/develop` branch (for the 3.2 docs), make changes, and then send a pull request.
 
- 1. Fork the specific repo you want to contribute to on github. (For example go to http://github.com/kohana/core and click the fork button.)
+### Long version
+
+(This still assumes you at least know your way around Git, especially how submodules work.)
+
+ 1. Fork the specific repo you want to contribute to on GitHub. (For example, go to http://github.com/kohana/core and click the fork button.)
 
  1. Now you need to add your fork as a "git remote" to your application and ensure you are on the right branch. An example for the [ORM](../orm) module and 3.2 docs:
-	
+
 		cd my-kohana-app/modules/orm
 
 		# add your repository as a new remote
 		git remote add <your name> git://github.com/<your name>/orm.git
-		
+
 		# Get the correct branch
 		git checkout 3.2/develop
-		
+
  1. Now go into the repo of the area of docs you want to contribute to and add your forked repo as a new remote, and push to it.
- 
+
 		cd my-kohana-app/modules/orm
 
 		# Make some changes to the docs
@@ -61,11 +65,11 @@ Once your pull request has been accepted, you can delete your repository if you 
 
 		# Commit your changes - Use a descriptive commit message! If there is a redmine ticket for the changes you are making include "Fixes #XXXXX" in the commit message so its tracked.
 		git commit -a -m "Corrected a typo in the ORM docs. Fixes #12345."
-		
+
 		# make sure we are up to date with the latest changes
 		git merge origin/3.2/develop
 
-		# Now push your changes to your fork.		
+		# Now push your changes to your fork.
 		git push <your name> 3.2/develop
 
- 1. Finally, Send a pull request on github.
+ 1. Finally, send a pull request on GitHub.


### PR DESCRIPTION
- GitHub is camelCase on the site, Git is capitalised, getting the docs to be consistent with casing
- Final sentence doesn't need capital letter in middle of sentence
- Subheading on "Short/Long" version needed the colons to match, figured it would read cleaner if the bolds were pushed up to subheads instead.

The newlines showing in diff don't change how it renders, since those lines weren't changed other than how the editor rendered them.
