### PR TITLE
Copyedits on Adding page, breaking it down into sections

### DIFF
--- a/guide/userguide/adding.md
+++ b/guide/userguide/adding.md
@@ -1,38 +1,42 @@
-# Adding your module to the userguide
+# Adding your module
 
-Making your module work with the userguide is simple.
+Making your module work with the User Guide is simple.
 
-First, copy this config and place in it `<module>/config/userguide.php`, replacing anything in `<>` with the appropriate things:
+First, copy this config and place in it `<module>/config/userguide.php`, replacing anything in `<>` with the appropriate values:
 
 	return array
 	(
 		// Leave this alone
 		'modules' => array(
-	
-			// This should be the path to this modules userguide pages, without the 'guide/'. Ex: '/guide/modulename/' would be 'modulename'
+
+			/*
+			 * The path to this module's userguide pages, without the 'guide/'.
+			 *
+			 * For example,  '/guide/modulename/' would be 'modulename'
+			 */
 			'<modulename>' => array(
-	
-				// Whether this modules userguide pages should be shown
+
+				// Whether this module's user guide pages should be shown
 				'enabled' => TRUE,
-				
-				// The name that should show up on the userguide index page
+
+				// The name that should show up on the user guide index page
 				'name' => '<Module Name>',
-	
+
 				// A short description of this module, shown on the index page
-				'description' => '<Description goes here.>',
-				
+				'description' => '<Description goes here>',
+
 				// Copyright message, shown in the footer for this module
-				'copyright' => '&copy; 2010–2011 <Your Name>',
-			)	
+				'copyright' => '&copy; 2012 <Your Name>',
+			)
 		),
 
 		/*
-		 * If you use transparent extension outside the Kohana_ namespace,
+		 * If you use transparent extensions outside the Kohana_ namespace,
 		 * add your class prefix here. Both common Kohana naming conventions are
-		 * excluded: 
+		 * excluded:
 		 *   - Modulename extends Modulename_Core
 		 *   - Foo extends Modulename_Foo
-		 * 
+		 *
 		 * For example, if you use Modulename_<class_name> for your base classes
 		 * then you would define:
 		 */
@@ -41,7 +45,11 @@ First, copy this config and place in it `<module>/config/userguide.php`, replaci
 		)
 	);
 
-Next, create a folder in your module directory called `guide/<modulename>` and create `index.md` and `menu.md`.  All userguide pages use [Markdown](markdown).  The index page is what is shown on the index of your module, the menu is what shows up in the side column.  The menu should be formatted like this:
+Next, create a folder in your module directory called `guide/<modulename>` and create `index.md` and `menu.md`.  The contents of `index.md` is what is shown on the index page of your module.
+
+## Creating the side menu
+
+The contents of the `menu.md` file is what shows up in the side column and should be formatted like this:
 
 	## [Module Name]()
 	 - [Page name](page-path)
@@ -52,4 +60,16 @@ Next, create a folder in your module directory called `guide/<modulename>` and c
 	 - Categories do not have to be a link to a page
 		 - [Etcetera](etc)
 
-Page paths are relative to `guide/<modulename>`.  So `[Page name](path-path)` would look for `guide/<modulename>/page-name.md` and `[Another](category/another)` would look for `guide/<modulename>/page-name.md`.   The guide pages can be named or arranged any way you want within that folder (with the exception of `menu.md` and `index.md`). The breadcrumbs and page titles are pulled from the `menu.md file`, not the file names or paths.  You can have items that are not pages (a category that doesn't have a corresponding page).  To link to the `index.md` page, you should have an empty link, e.g. `[Module Name]()`.  Do not include `.md` in your links.  
+You can have items that are not linked pages (a category that doesn't have a corresponding page).
+
+Guide pages can be named or arranged any way you want within that folder (with the exception of `index.md` and `menu.md` which must appear directly below the `guide/` folder).
+
+## Formatting page titles and links
+
+Page paths are relative to `guide/<modulename>`.  So `[Page name](page-name)` would look for `guide/<modulename>/page-name.md` and `[Another](category/another)` would look for `guide/<modulename>/category/another.md`.
+
+The breadcrumbs and page titles are pulled from the `menu.md` file, not the filenames or paths.
+
+To link to the `index.md` page, you should have an empty link, e.g. `[Module Name]()`.  Do not include `.md` in your links.
+
+All user guide pages use [Markdown](markdown).


### PR DESCRIPTION
Tried to create sections for the Adding page to better highlight the main things going on.

Also removed the side-scroll of the code example by pushing the comments across lines.

Not sure about the "user guide" with or without space, looked to the link top right of page to make consistent with.
