### PR TITLE
Hide breadcrumbs if there is only one element

### DIFF
--- a/views/userguide/template.php
+++ b/views/userguide/template.php
@@ -38,6 +38,7 @@
 	<div id="kodoc-content">
 		<div class="wrapper">
 			<div class="container">
+				<?php if (count($breadcrumb) > 1): ?>
 				<div class="span-22 prefix-1 suffix-1">
 					<ul id="kodoc-breadcrumb">
 						<?php foreach ($breadcrumb as $link => $title): ?>
@@ -49,6 +50,7 @@
 						<?php endforeach ?>
 					</ul>
 				</div>
+				<?php endif ?>
 				<div class="span-6 prefix-1">
 					<div id="kodoc-topics">
 						<?php echo $menu ?>


### PR DESCRIPTION
Breadcrumbs should be hidden if there is only one element to display, because it's always "Userguide" - not link, just text.
