### PR TITLE
Added preg_match() for generating link for 'uses constant'

### DIFF
--- a/classes/Kohana/Kodoc.php
+++ b/classes/Kohana/Kodoc.php
@@ -34,6 +34,10 @@ class Kohana_Kodoc {
 			{
 				$member = '#property:'.substr($matches[3], 1);
 			}
+			elseif (preg_match('/^[A-Z_\x7f-\xff][A-Z0-9_\x7f-\xff]*$/', $matches[3]))
+			{
+				$member = '#constant:'.substr($matches[3],0);
+			}
 			else
 			{
 				$member = '#'.$matches[3];


### PR DESCRIPTION
At the moment in some cases Kohana_Kodoc::link_class_member() generates incorrect links.
For example links Route::REGEX_ESCAPE, Route::REGEX_SEGMENT are incorrect: http://kohanaframework.org/3.3/guide-api/Route#compile

I think that would be a bit correctly, if we assume the constants as defined in http://www.php.net/manual/en/language.constants.php, and eliminating the lowercase letters from the $matches

(Sorry for my english)
