### PR TITLE
PHP7 support, remove deprecated PHP4 constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/classes/Kohana/Kodoc/Markdown.php
+++ b/classes/Kohana/Kodoc/Markdown.php
@@ -79,8 +79,8 @@ class Kohana_Kodoc_Markdown extends MarkdownExtra_Parser {
 		// Show table of contents for userguide pages
 		$this->document_gamut['doTOC'] = 100;
 
-		// PHP4 makes me sad.
-		parent::MarkdownExtra_Parser();
+		// Call parent constructor.
+		parent::__construct();
 	}
 	
 	/**

--- a/vendor/markdown/markdown.php
+++ b/vendor/markdown/markdown.php
@@ -239,7 +239,7 @@ class Markdown_Parser {
 	var $predef_titles = array();
 
 
-	function Markdown_Parser() {
+	function __construct() {
 	#
 	# Constructor function. Initialize appropriate member variables.
 	#
@@ -1669,7 +1669,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	var $predef_abbr = array();
 
 
-	function MarkdownExtra_Parser() {
+	function __construct() {
 	#
 	# Constructor function. Initialize the parser object.
 	#
@@ -1695,7 +1695,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			"doAbbreviations"    => 70,
 			);
 		
-		parent::Markdown_Parser();
+		parent::__construct();
 	}
 	
 	


### PR DESCRIPTION
Same as #79, this time removing only PHP4 style constructors.

Technically, this still breaks BC, however, in a minimal way, as only constructor methods' names are changed.

Please review.
